### PR TITLE
Adding space to loading indicator.

### DIFF
--- a/styles/overlays.less
+++ b/styles/overlays.less
@@ -22,6 +22,9 @@ atom-panel.modal, .overlay {
             box-shadow: 0 1px 0 @background-color-selected;
         }
     }
+    .select-list .loading {
+        padding: @component-padding;
+    }
     .select-list ol.list-group, .select-list ol.list-group {
         background-color: #FFF;
         border-radius: 0 0 @component-border-radius + 1px @component-border-radius + 1px;


### PR DESCRIPTION
The loading indicator that appears when indexing the project has no padding. I added in the default `@component-padding` (10px) to fix the appearance.