### PR TITLE
Enhancing tabs.

### DIFF
--- a/styles/accent-colors.less
+++ b/styles/accent-colors.less
@@ -11,6 +11,12 @@
             &::before {
                 background-color: @color;
             }
+            &.modified:not(:hover) .close-icon {
+                border-color: @color;
+            }
+        }
+        .placeholder::after {
+            border-top-color: @color;
         }
     }
     .focusable-panel {

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -64,6 +64,7 @@
             top: @tab-height/2 - @modified-icon-width/2 + 1px;
             width: @modified-icon-width;
             height: @modified-icon-width;
+            border-width: 1px;
         }
         &.modified:hover .close-icon:hover {
             color: #FFF;
@@ -143,13 +144,22 @@
             color: inherit;
         }
     }
+    .tab.is-dragging {
+        background: darken(@tab-background-color, 2%);
+    }
     .placeholder {
-        height: @tab-height + @tab-top-padding + @tab-bottom-border-height;
-        margin-left: -9px; // center between tabs
+        height: 100%;
+        margin: 0;
         pointer-events: none;
+        width: 0;
 
-        &:after {
-            top: @tab-height + @tab-top-padding + @tab-bottom-border-height - 2px;
+        &::after {
+            top: 0;
+            left: -6px;
+            margin: 0;
+            border-radius: 0;
+            border: 6px solid transparent;
+            background: transparent;
         }
     }
 }


### PR DESCRIPTION
The color of the modified close icon is now set to the configurable accent-color.

![screen shot 2015-06-24 at 11 13 00 pm](https://cloud.githubusercontent.com/assets/5902117/8346920/1180f616-1ac9-11e5-9c52-1e6b525ab14f.png)

===

Fixed the positioning of the placeholder while dragging tabs. The placeholder color is now set to the configurable accent-color. The background of the tab being dragged is no longer transparent.

![screen shot 2015-06-24 at 11 13 24 pm](https://cloud.githubusercontent.com/assets/5902117/8346921/11816c22-1ac9-11e5-8913-772a6445cb07.png)
