### PR TITLE
Hide animation artifact on tab when animations are disabled

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -172,6 +172,7 @@
             &.active {
                 &::before {
                     -webkit-animation: none;
+                    display: none;
                 }
             }
         }


### PR DESCRIPTION
There is a small visual artifact on the selected tab (see main.js in screenshot below) that appears when animations are disabled.

![screenshot at 140041](https://cloud.githubusercontent.com/assets/532439/8362050/a60c1ad8-1b44-11e5-94be-90d52b7b12a4.png)

This update hides the ::before element completely.