### PR TITLE
Add support for icons on all tabs

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -155,11 +155,13 @@ module.exports =
 
         # Tab Icons
 
-        setShowTabIcons = (boolean) ->
-            if boolean
-                root.classList.add('tab-icons')
-            else
-                root.classList.remove('tab-icons')
+        setShowTabIcons = (option) ->
+          root.classList.remove('tab-icons')
+          root.classList.remove('tab-icons-all')
+          if option == 'Show on active tab'
+              root.classList.add('tab-icons')
+          else if option == 'Show on all tabs'
+              root.classList.add('tab-icons-all')
 
         atom.config.onDidChange 'atom-material-ui.showTabIcons', ->
             setShowTabIcons(atom.config.get('atom-material-ui.showTabIcons'))

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -60,8 +60,9 @@ module.exports =
         showTabIcons:
             title: 'Icons in tabs'
             description: 'Shows the file-type icon for focused tabs. (Requires a package that enables file-type icons. i.e: file-icons, file-type-icons, seti-icons, etc…)'
-            type: 'boolean',
-            default: false
+            type: 'string'
+            default: 'Hide'
+            enum: ['Hide', 'Show on active tab', 'Show on all tabs']
         rippleAccentColor:
             title: 'Use accent color in tabs\' ripple effect'
             type: 'boolean',

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -254,6 +254,21 @@
         }
     }
 }
+.tab-icons-all {
+  .tab-bar {
+      .tab { // Specificity increase to prevent putting !important on transform
+          .title {
+              padding-left: 24px;
+          }
+          .title::before {
+              display: block !important;
+              width: auto;
+              height: auto;
+              transform: translateY(-50%) scale(1) !important;
+          }
+      }
+  }
+}
 .tab-size-small .tab-bar {
     .tab-size(32px);
 }


### PR DESCRIPTION
Not the most elegant configuration file, I think, but it works well. Resolves #53.

GIFs:

![bg](https://cloud.githubusercontent.com/assets/5153378/9059166/f679e700-3aea-11e5-96d6-37f42122c3ff.gif)

![bg2](https://cloud.githubusercontent.com/assets/5153378/9059167/fbbf19a6-3aea-11e5-9421-97e19ef24d3f.gif)

