### PR TITLE
Tooltips closer to the Material Design specs

### DIFF
--- a/styles/tooltips.less
+++ b/styles/tooltips.less
@@ -1,50 +1,42 @@
 @import "ui-variables";
 @import "keyframes";
 
+// Material Design tooltip specs
+// http://www.google.com/design/spec/components/tooltips.html
 .tooltip {
-    @tip-background-color: rgba(0,0,0,0.8);
+    @tip-background-color: @md-grey-700;
     @tip-text-color: #FFF;
     white-space: nowrap;
+    transition: opacity .5s @md-timing-function;
+    
+    .no-animations & {
+      transition: none;
+    }
+
+    .tooltip-arrow {
+      display: none;
+    }
 
     .keystroke {
-        font-family: Helvetica, Arial, sans-serif;
-        font-size: 13px;
-        color: #777;
+        color: fade(@tip-text-color, 30%);
         padding-left: 2px;
     }
-    &.in {
-        -webkit-animation: circleReveal 500ms ease;
-    }
+
     .tooltip-inner {
-        line-height: 19px;
+        line-height: 22px;
+        padding: 0 8px;
         border-radius: @component-border-radius;
         background-color: @tip-background-color;
         color: @tip-text-color;
         white-space: nowrap;
         max-width: none;
     }
-    &.top .tooltip-arrow {
-        border-top-color: @tip-background-color;
+
+    &.top,
+    &.bottom {
+      margin-top: 0;
+      padding: 14px 0;
     }
-    &.top-left .tooltip-arrow {
-        border-top-color: @tip-background-color;
-    }
-    &.top-right .tooltip-arrow {
-        border-top-color: @tip-background-color;
-    }
-    &.right .tooltip-arrow {
-        border-right-color: @tip-background-color;
-    }
-    &.left .tooltip-arrow {
-        border-left-color: @tip-background-color;
-    }
-    &.bottom .tooltip-arrow {
-        border-bottom-color: @tip-background-color;
-    }
-    &.bottom-left .tooltip-arrow {
-        border-bottom-color: @tip-background-color;
-    }
-    &.bottom-right .tooltip-arrow {
-        border-bottom-color: @tip-background-color;
-    }
+
+    // Google has no specs on left-right tooltip margin placement (actually top too, but it's quite similar to bottom), so no need to edit the margin and padding of them
 }

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -116,8 +116,11 @@
 @md-deep-orange:    #FF5722;
 @md-brown:          #795548;
 @md-grey:           #9E9E9E;
+@md-grey-700:       #616161;
 @md-blue-grey:      #607D8B;
 
 // Accent Colors
 
 @background-color-selected: @md-blue-grey;
+
+@md-timing-function: cubic-bezier(.4, 0, .2, 1);


### PR DESCRIPTION
The specs say it has to be in Grey 700 background, white text, 22px in height, 14px from the element, 0.9 opacity, and no arrows. Digging Polymer results in a 0.5s opacity transition with the default timing cubic-bezier.

I added `@md-grey-700` for the color and `@md-timing-function` for the timing. Because of how the tooltips get deleted I can't add the fadeout transition. Also the 14px margin from the element gets applied to top and bottom tooltips only — the left and right tooltip margins is kept intact since there's no docs on left and right tooltip margins (also top, but it's quite similar with the bottom counterpart).

Here's a GIF.

![](https://cloud.githubusercontent.com/assets/5153378/9256136/220db9e4-4231-11e5-916a-fdc9f0f0bc2c.gif)
