### PR TITLE
Fix invisible labels of jumpy

### DIFF
--- a/index.less
+++ b/index.less
@@ -25,3 +25,4 @@
 @import "styles/tree-view";
 @import "styles/utilities";
 @import "styles/accent-colors";
+@import "styles/jumpy";

--- a/styles/jumpy.less
+++ b/styles/jumpy.less
@@ -1,0 +1,6 @@
+@import "ui-variables";
+
+atom-text-editor::shadow .jumpy.label {
+    color: @app-background-color;
+    background-color: @text-color;
+}


### PR DESCRIPTION
[Jumpy](//atom.io/packages/jumpy)

Before:
![7](https://cloud.githubusercontent.com/assets/12756700/9722787/0935a338-55ef-11e5-986c-809db6e7e79a.png)
After:
![5](https://cloud.githubusercontent.com/assets/12756700/9722789/106a2ea8-55ef-11e5-8c58-b4e53cbe64b0.png)

This problem that is peculiar to the theme.