### PR TITLE
Fix problem with tree view scrollbar rendering incorrectly

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -33,6 +33,9 @@
         width: 8px;
     }
 }
+.tree-view-scroller {
+    transform: translate3d(0, 0, 0);
+}
 .focusable-panel {
     opacity: 1;
 


### PR DESCRIPTION
This fixes an issue I noticed under linux in which the scroll bar for the tree view does not render correctly.
To reproduce the problem:
* open atom in a directory with enough files to make the vertical scrollbar appear
* make sure that a sorce file is open in the text editor (the problem does not occur when viewing the initial screen or the settings tab)
* scroll the tree view up or down

I can see this problem occurring in Linux Mint and Ubuntu. It looks ok under Windows, while I haven't tried on Mac. It also seems to happen with any syntax theme while using atom-material-ui.

Below is an animation showing the problem:

![gifrecord_2015-10-12_225411](https://cloud.githubusercontent.com/assets/10583213/10427519/1998a042-7136-11e5-83c4-baf059a69495.gif)


This is probably the same problem as issue #104.