### PR TITLE
Make the modified file indicator easier to recognize for inactive tabs

### DIFF
--- a/styles/accent-colors.less
+++ b/styles/accent-colors.less
@@ -8,7 +8,7 @@
                     background-color: fade(@color, 50%);
                 }
                 &.modified:not(:hover) .title::after {
-                    border-color: fade(@color, 60%);
+                    border-color: fade(@color, 87%);
                 }
             }
         }

--- a/styles/accent-colors.less
+++ b/styles/accent-colors.less
@@ -7,6 +7,9 @@
                 &::before {
                     background-color: fade(@color, 50%);
                 }
+                &.modified:not(:hover) .title::after {
+                    border-color: fade(@color, 60%);
+                }
             }
         }
     }

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -39,7 +39,7 @@
 
         .close-icon {
             right: 10px;
-            z-index: 3;
+            z-index: 3;f
             text-align: right;
             line-height: @tab-height;
             color: @text-color;
@@ -78,7 +78,7 @@
             border-radius: 50%;
             width: @modified-icon-width;
             height: @modified-icon-width;
-            border: 2px solid fade(@text-color, 60%);
+            border: 2px solid @tab-border-color;
         }
         .title {
             position: relative;

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -39,7 +39,7 @@
 
         .close-icon {
             right: 10px;
-            z-index: 3;f
+            z-index: 3;
             text-align: right;
             line-height: @tab-height;
             color: @text-color;


### PR DESCRIPTION
Easier to recognize what modified files haven't been saved.

The faded white circle was hard to catch at a glance, especially if you had too many tabs open.