### PR TITLE
Modified file indicator not showing up properly on inactive tabs

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -82,6 +82,7 @@
             border-radius: 50%;
             width: @modified-icon-width;
             height: @modified-icon-width;
+            border: 2px solid @tab-border-color;
         }
         .title {
             position: relative;


### PR DESCRIPTION
Looks like the line border: 2px solid @tab-border-color; was removed in another one of your commits.
When a modified tab was inactive the modified file indicator was not visible.
After most recent update:
<img width="374" alt="screenshot 2015-11-10 12 39 38" src="https://cloud.githubusercontent.com/assets/1510356/11075324/9a72ebd0-87a9-11e5-9180-329a61f1e0f5.png">
Should look like this:
<img width="374" alt="screenshot 2015-11-10 12 40 53" src="https://cloud.githubusercontent.com/assets/1510356/11075336/a2d5791e-87a9-11e5-9745-f9371e4adef6.png">
