### PR TITLE
Removed redundant styles and normalized icon size of tool-bar.

### DIFF
--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -36,7 +36,7 @@
             
             &:before {
                 // NOTE: should be configured by ui scaling setting
-                font-size: 20px;
+                font-size: 1.25rem;
             }
         }
     }

--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -1,7 +1,6 @@
 // NOTE: color of buttons on hover needs adjusting
 
 .tool-bar {
-    position: relative;
     background: darken(@app-background-color, 0%);
     border: none;
     
@@ -36,6 +35,7 @@
             border-radius: 0;
             
             &:before {
+                // NOTE: should be configured by ui scaling setting
                 font-size: 20px;
             }
         }

--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -1,50 +1,48 @@
-.tool-bar {
-    &.tool-bar-horizontal {
-        position: relative;
-        height: 3rem;
-        z-index: 100;
-        border: none;
-        background: @accent-color;
+// NOTE: color of buttons on hover needs adjusting
 
-        &.tool-bar-24px {
-            .tool-bar-btn {
-                width: 3rem;
-                height: 3rem;
-                line-height: 3rem;
-                padding: 0;
-                margin: 0;
-                .text-color(@accent-color);
-            }
-        }
-        .tool-bar-spacer {
-            margin: 0 0.5rem;
-            border: none;
+.tool-bar {
+    position: relative;
+    background: darken(@app-background-color, 0%);
+    border: none;
+    
+    &.tool-bar-top {
+        background: @accent-color;
+        .text-color(@accent-color);
+    }
+    
+    &.tool-bar-vertical {
+        width: 3rem;
+        padding-top: 3rem;
+        
+        .tool-bar-btn:first-child {
+            position: absolute;
+            top: 0;
+            z-index: 100;
+            background: @accent-color;
+            .text-color(@accent-color);
         }
     }
-    &.tool-bar-vertical {
-        background: darken(@app-background-color, 3.5%);
-        padding: 0;
-        width: 3rem;
-        border: none;
-        box-shadow: inset -0.125rem 0 0.125rem rgba(0,0,0,0.05);
-
-        &.tool-bar-24px {
-            .tool-bar-btn {
-                padding: 0;
-                height: 3rem;
-                width: 3rem;
-                margin: 0;
-                border-radius: 0;
-
-                &:first-child {
-                    background: darken(@accent-color, 5%);
-                    .text-color(@accent-color);
-                }
+    
+    &.tool-bar-horizontal {
+        height: 3rem;
+    }
+    
+    &.tool-bar-16px, &.tool-bar-24px, &.tool-bar-32px {
+        button.tool-bar-btn {
+            width: 3rem;
+            height: 3rem;
+            margin: 0;
+            padding: 0;
+            border-radius: 0;
+            
+            &:before {
+                font-size: 20px;
             }
         }
-        .tool-bar-spacer {
-            border: none;
-            border-bottom: 1px solid darken(@app-background-color, 5%);
-        }
+    }
+    
+    .tool-bar-spacer {
+        border: none;
+        border-bottom: 1px solid darken(@app-background-color, 5%);
     }
 }


### PR DESCRIPTION
I refactored the styles to remove duplication of definitions. Also
manually defined the icon size regardless of the setting chosen for the
tool-bar package. This should eventually be configured via a UI scaling
option in the material-ui settings.

I seem to have broken the toolbar when in the top position so that will
need to be looked at at some point and fixed.

The hover color of the buttons also needs to be defined correctly. I
wasn't sure whether it should be defined here or if there was a global
definition for button styles somewhere which would be more appropriate.