### PR TITLE
Fix: fade out ignored directories and files in the tree view

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -48,6 +48,9 @@
             .selected-item;
         }
     }
+    li.status-ignored {
+        color: fade(@text-color, 30%);
+    }
     &:focus {
         li.directory.selected > div.header.list-item {
             color: @accent-text-color;


### PR DESCRIPTION
This PR fades out the ignored directories and files (e.g. node_modules) in the tree view.
I think this was the previous behavior before v1.0.0
Fixes: https://github.com/silvestreh/atom-material-ui/issues/150

![image](https://cloud.githubusercontent.com/assets/2353186/11518453/2a0eb0e0-9889-11e5-88dd-c2f58e681bab.png)
