### PR TITLE
Tweak the text input font size

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -6,7 +6,7 @@ atom-text-editor[mini], atom-text-editor[mini]::shadow {
     background-color: transparent;
     border: none;
     border-radius: 0;
-    font-size: 0.8rem;
+    font-size: 0.875rem;
     line-height: 1.25rem;
     padding: 0.75rem 0;
     max-height: none;


### PR DESCRIPTION
The previous value of `0.8rem` made the characters looks too small
in comparison with the input's height.

The change, albeit subtle, provides a clearer look and visual
confort without compromising line length or looking disproportional.

Fix #166 