### PR TITLE
Fixed first button same background color as tab bar on vertical tool bar 

### DIFF
--- a/styles/packages/tool-bar.less
+++ b/styles/packages/tool-bar.less
@@ -116,13 +116,19 @@
     }
     .tinted-tab-bar & {
         &.tool-bar-vertical {
-            .tool-bar-btn:first-child {
+            .tool-bar-btn {
                 background: darken(@base-color, 5%);
                 color: @accent-text-color;
 
                 svg path, svg polygon {
                     fill: @accent-text-color;
                 }
+            }
+            .tool-bar-btn.tool-bar-item-align-end,
+            .tool-bar-btn:not(.tool-bar-item-align-end) + .tool-bar-btn,
+            .tool-bar-spacer + .tool-bar-btn {
+                background: none;
+                color: @text-color;
             }
         }
         &.tool-bar-top {


### PR DESCRIPTION
Fixed first button same background color as tab bar on vertical tool bar with new item [aligned to the end](https://github.com/suda/tool-bar/pull/110) feature. This was part of the recently released version of [Tool Bar](https://atom.io/packages/tool-bar) package.

| Before | After |
| --- | --- |
| ![tool-bar-before](https://cloud.githubusercontent.com/assets/55841/13548521/8c5646d8-e2f2-11e5-8783-58a8098a12a8.png) | ![tool-bar-after](https://cloud.githubusercontent.com/assets/55841/13548525/99a5eb7c-e2f2-11e5-9dd1-60bdc1a1f31b.png)  |

