### PR TITLE
Make compatible with next version of Atom Build

### DIFF
--- a/styles/packages/build.less
+++ b/styles/packages/build.less
@@ -1,50 +1,27 @@
 .build {
     .control-container {
-        background-color: darken(@app-background-color, 3%);
-        width: 7rem;
-        padding: 0.5rem;
-        text-align: center;
-
         .btn {
-            float: none;
-            color: @text-color;
-            width: 2.5rem;
-            height: 2.5rem;
-            line-height: 2.5rem;
-            text-align: center;
-            padding: 0;
-            margin: 0 0 0.5rem;
+            height: 1.5rem;
+            line-height: 1.5rem;
+        }
+    }
 
-            &:nth-child(2n) {
-                margin-left: 0.5rem;
-            }
-        }
-        .title {
-            line-height: 1rem;
-            display: inline-block;
-        }
-        .icon-gear {
-            display: inline-block;
-            width: 1rem;
-            height: 1rem;
-            text-align: center;
-            line-height: 1rem;
-        }
+    .panel-heading {
+        margin-bottom: 0;
+        padding: 5px;
     }
-    .output {
-        background-color: @app-background-color;
-        min-height: 8.75rem;
-        border-top: 1px solid darken(@app-background-color, 1.5%);
-    }
+
     .panel-contrast & {
         .output {
             background-color: darken(@app-background-color, 0.5%);
         }
     }
+
     .panel-shadows & {
         .z-depth-1;
     }
 }
+
 #build-status-bar {
     margin-right: 1rem;
 


### PR DESCRIPTION
I've made some quick fixes to make the new version of Atom Build work. It's not great, but it's something:
![screen shot 2016-03-08 at 21 38 50](https://cloud.githubusercontent.com/assets/933880/13615561/3b5135fa-e576-11e5-92bf-1ed6f28b7a34.png)

It works okayish with the current version, so coordinated releases should not be required.

What do you think?

Fixes #240 