### PR TITLE
Make linter-message use min-height

### DIFF
--- a/styles/packages/linter.less
+++ b/styles/packages/linter.less
@@ -69,7 +69,7 @@ linter-message {
         border-color: transparent transparent @text-color @text-color;
     }
     linter-message {
-        height: 1.85rem;
+        min-height: 1.85rem;
 
         span:last-child {
             color: @app-background-color;


### PR DESCRIPTION
A `#linter-inline > linter-message` can have an expando-arrow on it. this theme’s style doesn’t allow it to expand as of now.

makings its height to flexible using `min-height` instead of `height` fixes that