### PR TITLE
[FIX] #452

### DIFF
--- a/styles/packages/tool-bar.less
+++ b/styles/packages/tool-bar.less
@@ -3,7 +3,7 @@
     z-index: 5000;
 
     &.tool-bar-vertical .tool-bar-spacer {
-        margin: 0.5rem 0;
+        margin: 0.5rem auto;
         border-bottom: none;
     }
 
@@ -29,7 +29,7 @@
     &.tool-bar-horizontal,
     &.tool-bar-vertical {
         .tool-bar-spacer {
-            border-color: fade(@text-color, 5%);
+            border-color: fade(@accent-text-color, 5%);
         }
 
         &.gutter-bottom,

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -106,11 +106,17 @@
     }
 
     .placeholder {
-        height: @tab-height + @tab-top-padding + @tab-bottom-border-height;
+        height: @tab-height;
         pointer-events: none;
+        .amu-compact-tab-bar & {
+            height: @compact-tab-height;
+            &:after {
+                top: @compact-tab-height - 2px;
+            }
+        }
 
         &:after {
-            top: @tab-height + @tab-top-padding + @tab-bottom-border-height - 2px;
+            top: @tab-height - 2px;
         }
     }
 
@@ -184,14 +190,14 @@
     position: relative;
 
     &::before {
-        content: '';
+        content: "";
         background: linear-gradient(to bottom, black, transparent);
         position: absolute;
         top: 0;
         left: 0;
         width: 100%;
         height: 3px;
-        opacity: .125;
+        opacity: 0.125;
         pointer-events: none;
         z-index: 10;
     }


### PR DESCRIPTION
Fix an issue with multiline-tab package
Fix an issue with tool-bar package separator in vertical mode.

### Description of the Change

#### multiline-tab:
Fix an issue that caused the .placeholder when dragging tabs to be 10rem height. Since multiline-tabs package disabled the vertical overflow of the tab bar to allow wrapping, this caused an issue where the placeholder would span multiple row of tabs. Now the placeholder with be the same height as the tab( 3rem, or 2.5rem if compact mode is enabled)

#### tool-bar:
Fix and issue that caused separator to be left-aligned instead of centered when the tool-bar is set in vertical mode. Also correct the separator color variable so it's not as light and work with more theme The color is now 5% lighter then the icon instead of 5% lighter than the text which make more sense.

### Benefits

Fix a compatibility issue with two widely used package

### Possible Drawbacks

None that I see.

### Applicable Issues

#452, #460 